### PR TITLE
handle unsupported type

### DIFF
--- a/core/atomic_components/avatar_registrar.py
+++ b/core/atomic_components/avatar_registrar.py
@@ -72,10 +72,8 @@ class AvatarRegistrar:
             crop_vy_ratio: -0.125
             crop_flag_do_rot: True
         """
-        try:
-            rgb_list, is_image_flag = load_source_frames(source_path, max_dim=max_dim, n_frames=n_frames)
-        except UnsupportedSourceException as e:
-            raise e
+        rgb_list, is_image_flag = load_source_frames(source_path, max_dim=max_dim, n_frames=n_frames)
+        
 
         source_info = {
             "x_s_info_lst": [],

--- a/core/atomic_components/avatar_registrar.py
+++ b/core/atomic_components/avatar_registrar.py
@@ -73,8 +73,6 @@ class AvatarRegistrar:
             crop_flag_do_rot: True
         """
         rgb_list, is_image_flag = load_source_frames(source_path, max_dim=max_dim, n_frames=n_frames)
-        
-
         source_info = {
             "x_s_info_lst": [],
             "f_s_lst": [],

--- a/core/atomic_components/avatar_registrar.py
+++ b/core/atomic_components/avatar_registrar.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .loader import load_source_frames
 from .source2info import Source2Info
-
+from ..utils.exceptions import UnsupportedSourceException
 
 def _mean_filter(arr, k):
     n = arr.shape[0]
@@ -72,7 +72,11 @@ class AvatarRegistrar:
             crop_vy_ratio: -0.125
             crop_flag_do_rot: True
         """
-        rgb_list, is_image_flag = load_source_frames(source_path, max_dim=max_dim, n_frames=n_frames)
+        try:
+            rgb_list, is_image_flag = load_source_frames(source_path, max_dim=max_dim, n_frames=n_frames)
+        except UnsupportedSourceException as e:
+            raise e
+
         source_info = {
             "x_s_info_lst": [],
             "f_s_lst": [],

--- a/core/atomic_components/loader.py
+++ b/core/atomic_components/loader.py
@@ -1,6 +1,7 @@
 import filetype
 import imageio
 import cv2
+from ..utils.exceptions import UnsupportedSourceException
 
 
 def is_image(file_path):
@@ -79,7 +80,7 @@ def load_source_frames(source_path, max_dim=-1, n_frames=-1):
         rgb_list = load_video(source_path, n_frames, max_dim)
         is_image_flag = False
     else:
-        raise ValueError(f"Unsupported source type: {source_path}")
+        raise UnsupportedSourceException(source=source_path)
     return rgb_list, is_image_flag
 
 

--- a/core/utils/exceptions.py
+++ b/core/utils/exceptions.py
@@ -1,0 +1,18 @@
+class UnsupportedSourceException(RuntimeError):
+   """Exception raised when an unsupported data source is encountered.
+   
+   This exception is raised when attempting to process or interact with
+   a data source that is not supported by the current implementation.
+   """
+   
+   def __init__(self, message: str ="Unsupported data source", source: str=""):
+       """Initialize the exception.
+       
+       Args:
+           message (str): Error message describing the exception
+           source (str, optional): The unsupported source identifier
+       """
+       if source:
+           message = f"{message}: {source}"
+       super().__init__(message)
+       self.source = source

--- a/stream_pipeline_online.py
+++ b/stream_pipeline_online.py
@@ -23,6 +23,7 @@ from .core.atomic_components.warp_f3d import WarpF3D
 from .core.atomic_components.wav2feat import Wav2Feat
 from .core.utils.profiling_utils import FPSTracker
 from .core.utils.threading_utils import AtomicCounter
+from .core.utils.exceptions import UnsupportedSourceException
 
 """
 avatar_registrar_cfg:
@@ -324,12 +325,15 @@ class StreamSDK:
         }
         n_frames = self.template_n_frames if self.template_n_frames > 0 else self.N_d
         if source_info is None:
-            source_info = self.avatar_registrar(
-                source_path,
-                max_dim=self.max_size,
-                n_frames=n_frames,
-                **crop_kwargs,
-            )
+            try:
+                source_info = self.avatar_registrar(
+                    source_path,
+                    max_dim=self.max_size,
+                    n_frames=n_frames,
+                    **crop_kwargs,
+                )
+            except UnsupportedSourceException as e:
+                raise e
 
         if len(source_info["x_s_info_lst"]) > 1 and self.smo_k_s > 1:
             source_info["x_s_info_lst"] = smooth_x_s_info_lst(

--- a/stream_pipeline_online.py
+++ b/stream_pipeline_online.py
@@ -325,15 +325,12 @@ class StreamSDK:
         }
         n_frames = self.template_n_frames if self.template_n_frames > 0 else self.N_d
         if source_info is None:
-            try:
-                source_info = self.avatar_registrar(
-                    source_path,
-                    max_dim=self.max_size,
-                    n_frames=n_frames,
-                    **crop_kwargs,
-                )
-            except UnsupportedSourceException as e:
-                raise e
+            source_info = self.avatar_registrar(
+                source_path,
+                max_dim=self.max_size,
+                n_frames=n_frames,
+                **crop_kwargs,
+            )
 
         if len(source_info["x_s_info_lst"]) > 1 and self.smo_k_s > 1:
             source_info["x_s_info_lst"] = smooth_x_s_info_lst(

--- a/stream_pipeline_online.py
+++ b/stream_pipeline_online.py
@@ -23,7 +23,6 @@ from .core.atomic_components.warp_f3d import WarpF3D
 from .core.atomic_components.wav2feat import Wav2Feat
 from .core.utils.profiling_utils import FPSTracker
 from .core.utils.threading_utils import AtomicCounter
-from .core.utils.exceptions import UnsupportedSourceException
 
 """
 avatar_registrar_cfg:


### PR DESCRIPTION
This pull request introduces a new custom exception, `UnsupportedSourceException`, to improve error handling when an unsupported data source is encountered during avatar registration and source frame loading. The codebase is updated to raise and handle this exception in relevant components, replacing the previous use of a generic `ValueError`.

**Error handling improvements:**

* Added a new exception class, `UnsupportedSourceException`, in `core/utils/exceptions.py` to provide clearer error messages and context when unsupported data sources are processed.
* Updated `core/atomic_components/loader.py` to raise `UnsupportedSourceException` instead of `ValueError` when an unsupported source type is detected in `load_source_frames`.
* Updated imports in `core/atomic_components/avatar_registrar.py`, `core/atomic_components/loader.py`, and `stream_pipeline_online.py` to include `UnsupportedSourceException`. [[1]](diffhunk://#diff-98d6cbe114bc9f9e00bfef20d0843fbdf8db99aca95562ceedc659088ac2a7f2L5-R5) [[2]](diffhunk://#diff-9bb4f412fa1b894d06c09e84a62a910d7326093e1ac84bd2e27df178f0a0f816R4) [[3]](diffhunk://#diff-1bedd4291d10570d6baa7b17bc6f368dc644c6fbc3bad7d6ae935006f0b948c5R26)

**Exception propagation and handling:**

* Wrapped calls to `load_source_frames` in `avatar_registrar.py` and to `avatar_registrar` in `stream_pipeline_online.py` with try/except blocks to catch and re-raise `UnsupportedSourceException`, ensuring consistent error propagation. [[1]](diffhunk://#diff-98d6cbe114bc9f9e00bfef20d0843fbdf8db99aca95562ceedc659088ac2a7f2R75-R79) [[2]](diffhunk://#diff-1bedd4291d10570d6baa7b17bc6f368dc644c6fbc3bad7d6ae935006f0b948c5R328-R336)